### PR TITLE
Wrong path for anticamp_csgo_weapons.cfg

### DIFF
--- a/addons/sourcemod/scripting/anticamp.sp
+++ b/addons/sourcemod/scripting/anticamp.sp
@@ -127,16 +127,6 @@ public OnPluginStart()
 
 	decl String:gamedir[PLATFORM_MAX_PATH];
 	GetGameFolderName(gamedir, sizeof(gamedir));
-	if(strcmp(gamedir, "cstrike") == 0)
-	{
-		g_iGame = GAME_CSS;
-		WeaponConfigFile = "configs/anticamp_css_weapons.cfg";
-	}
-	else
-	{
-		g_iGame = GAME_CSGO;
-		WeaponConfigFile = "configs/anticamp_csgo_weapons.cfg";
-	}
 
 	HookEvent("player_spawn", EventPlayerSpawn, EventHookMode_Post);
 	HookEvent("player_death", EventPlayerDeath, EventHookMode_PostNoCopy);


### PR DESCRIPTION
Hi 
anticamp_csgo_weapons.cfg is created in /cfg/sourcemod but plugins search in 

L 06/01/2017 - 07:39:17: [anticamp.smx] addons/sourcemod/configs/anticamp_csgo_weapons.cfg not parsed...file doesn't exist! Using sm_anticamp_camptime